### PR TITLE
Explicitly remove default namespace for Swagger UI

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -8,4 +8,5 @@ api = Api(
 	version=API_VERSION,
 	description=API_DESC)
 
+api.namespaces.clear()
 api.add_namespace(model_ns)

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ DEBUG = False
 
 # Flask-restplus settings
 RESTPLUS_MASK_SWAGGER = False
-SWAGGER_UI_DOC_EXPANSION = 'list'
+SWAGGER_UI_DOC_EXPANSION = 'none'
 
 # API metadata
 API_TITLE = 'Model Asset Exchange Server'


### PR DESCRIPTION
This removes the `default` (unused) API namespace to force Swagger UI not to display it.

Refer to https://github.com/IBM/MAX-Object-Detector/pull/16 for reference - this PR is the same change to be applied across all MAX repos where relevant.