### PR TITLE
set max-base to v1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codait/max-base
+FROM codait/max-base:v1.0.0
 
 ARG model_bucket=http://max-assets.s3-api.us-geo.objectstorage.softlayer.net/keras
 ARG model_file=inception_resnet_v2.h5


### PR DESCRIPTION
Pegged to max-base v1.0.0 per the discussion on https://github.com/IBM/MAX-Framework/pull/6